### PR TITLE
Add missing metadata

### DIFF
--- a/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,9 @@
+---
+name: "Zeebe"
+metadata:
+  keywords:
+  - "camunda"
+  - "zeebe"
+  - "bpmn"
+  categories:
+    - "business automation"


### PR DESCRIPTION
I noticed this extension is missing its [extension metadata file](https://quarkus.io/version/main/guides/extension-metadata#quarkus-extension-yaml). That means it doesn't display as nicely on http://code.quarkus.io/ or https://quarkus.io/extensions/.

<img width="313" alt="image" src="https://user-images.githubusercontent.com/11509290/225578703-39b3ffa8-65fb-4440-8b0a-8ddcdafcdfcd.png">

I've put in a file with what seems like sensible information. It might also be worth adding a status (I couldn't guess at what the right value should be!).