### PR TITLE
Added an object mapper injection

### DIFF
--- a/runtime/src/main/java/io/quarkiverse/zeebe/ZeebeResourcesProducer.java
+++ b/runtime/src/main/java/io/quarkiverse/zeebe/ZeebeResourcesProducer.java
@@ -2,7 +2,9 @@ package io.quarkiverse.zeebe;
 
 import javax.enterprise.inject.Produces;
 import javax.inject.Singleton;
+import javax.inject.Inject;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.impl.ZeebeObjectMapper;
 import io.quarkus.arc.DefaultBean;
@@ -12,12 +14,19 @@ import io.smallrye.mutiny.infrastructure.Infrastructure;
 @Singleton
 public class ZeebeResourcesProducer {
 
+    protected final ObjectMapper objectMapper;
+
+    @Inject
+    public ZeebeResourcesProducer(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
     @Produces
     @Singleton
     @Unremovable
     @DefaultBean
     public JsonMapper defaultJsonMapper() {
-        return new ZeebeObjectMapper();
+        return new ZeebeObjectMapper(objectMapper);
     }
 
     @Produces


### PR DESCRIPTION
Greetings, it was necessary to add support for the Java Time Module. But since the constructor inside camunda did not allow this, we had to add a dependency injection.