### PR TITLE
Feat/make oauth audience configurable

### DIFF
--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,5 +1,5 @@
-:project-version: 1.0.1
-:quarkus-version: 3.2.2.Final
+:project-version: 1.1.0
+:quarkus-version: 3.2.3.Final
 
 :quarkus-mockserver-url: https://github.com/quarkiverse/quarkus-zeebe
 

--- a/docs/modules/ROOT/pages/includes/quarkus-zeebe.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-zeebe.adoc
@@ -666,7 +666,7 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_ZEEBE_CLIENT_OAUTH_TOKEN_AUDIENCE+++`
 endif::add-copy-button-to-env-var[]
 --|string 
-|`zeebe.camunda.io`
+|
 
 
 a| [[quarkus-zeebe_quarkus.zeebe.client.auto-complete.max-retries]]`link:#quarkus-zeebe_quarkus.zeebe.client.auto-complete.max-retries[quarkus.zeebe.client.auto-complete.max-retries]`

--- a/docs/modules/ROOT/pages/includes/quarkus-zeebe.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-zeebe.adoc
@@ -653,6 +653,22 @@ endif::add-copy-button-to-env-var[]
 |`PT5S`
 
 
+a| [[quarkus-zeebe_quarkus.zeebe.client.oauth.token-audience]]`link:#quarkus-zeebe_quarkus.zeebe.client.oauth.token-audience[quarkus.zeebe.client.oauth.token-audience]`
+
+[.description]
+--
+Zeebe token audience
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ZEEBE_CLIENT_OAUTH_TOKEN_AUDIENCE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ZEEBE_CLIENT_OAUTH_TOKEN_AUDIENCE+++`
+endif::add-copy-button-to-env-var[]
+--|string 
+|`zeebe.camunda.io`
+
+
 a| [[quarkus-zeebe_quarkus.zeebe.client.auto-complete.max-retries]]`link:#quarkus-zeebe_quarkus.zeebe.client.auto-complete.max-retries[quarkus.zeebe.client.auto-complete.max-retries]`
 
 [.description]

--- a/runtime/src/main/java/io/quarkiverse/zeebe/runtime/ZeebeClientBuilderFactory.java
+++ b/runtime/src/main/java/io/quarkiverse/zeebe/runtime/ZeebeClientBuilderFactory.java
@@ -60,7 +60,7 @@ public class ZeebeClientBuilderFactory {
             oauth.clientSecret.ifPresent(builder::clientSecret);
             oauth.credentialsCachePath.ifPresent(builder::credentialsCachePath);
 
-            builder.audience(oauth.tokenAudience);
+            builder.audience(createOauthAudience(config));
 
             // setup connection timeout
             builder.connectTimeout(oauth.connectTimeout);
@@ -68,6 +68,19 @@ public class ZeebeClientBuilderFactory {
             return builder.build();
         }
         return null;
+    }
+
+    private static String createOauthAudience(ZeebeClientRuntimeConfig config) {
+        return config.oauth.tokenAudience.orElseGet(
+                () -> removePortFromAddress(config.broker.gatewayAddress));
+    }
+
+    private static String removePortFromAddress(String address) {
+        int index = address.lastIndexOf(':');
+        if (index > 0) {
+            return address.substring(0, index);
+        }
+        return address;
     }
 
 }

--- a/runtime/src/main/java/io/quarkiverse/zeebe/runtime/ZeebeClientBuilderFactory.java
+++ b/runtime/src/main/java/io/quarkiverse/zeebe/runtime/ZeebeClientBuilderFactory.java
@@ -60,11 +60,7 @@ public class ZeebeClientBuilderFactory {
             oauth.clientSecret.ifPresent(builder::clientSecret);
             oauth.credentialsCachePath.ifPresent(builder::credentialsCachePath);
 
-            // remove port from the gateway address
-            int index = config.broker.gatewayAddress.lastIndexOf(':');
-            if (index > 0) {
-                builder.audience(config.broker.gatewayAddress.substring(0, index));
-            }
+            builder.audience(oauth.tokenAudience);
 
             // setup connection timeout
             builder.connectTimeout(oauth.connectTimeout);

--- a/runtime/src/main/java/io/quarkiverse/zeebe/runtime/ZeebeClientRuntimeConfig.java
+++ b/runtime/src/main/java/io/quarkiverse/zeebe/runtime/ZeebeClientRuntimeConfig.java
@@ -441,8 +441,8 @@ public class ZeebeClientRuntimeConfig {
         /**
          * Zeebe token audience
          */
-        @ConfigItem(name = "token-audience", defaultValue = "zeebe.camunda.io")
-        public String tokenAudience;
+        @ConfigItem(name = "token-audience")
+        public Optional<String> tokenAudience;
     }
 
 }

--- a/runtime/src/main/java/io/quarkiverse/zeebe/runtime/ZeebeClientRuntimeConfig.java
+++ b/runtime/src/main/java/io/quarkiverse/zeebe/runtime/ZeebeClientRuntimeConfig.java
@@ -437,6 +437,12 @@ public class ZeebeClientRuntimeConfig {
          */
         @ConfigItem(name = "read-timeout", defaultValue = "PT5S")
         public Duration readTimeout;
+
+        /**
+         * Zeebe token audience
+         */
+        @ConfigItem(name = "token-audience", defaultValue = "zeebe.camunda.io")
+        public String tokenAudience;
     }
 
 }


### PR DESCRIPTION
Previuos the login via oauth did not work with the the audience `zeebe.camunda.io` and a zeebe address like `<cluster-id>.bru-2.zeebe.camunda.io:443`