### PR TITLE
Dev UI: always produce JsonRPCProvidersBuildItem

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/zeebe/devservices/DevUIZeebeProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/zeebe/devservices/DevUIZeebeProcessor.java
@@ -30,8 +30,7 @@ public class DevUIZeebeProcessor {
             BuildProducer<RouteBuildItem> routes,
             BuildProducer<CardPageBuildItem> cardsProducer,
             NonApplicationRootPathBuildItem nonApplicationRootPathBuildItem,
-            BuildProducer<MenuPageBuildItem> menuProducer,
-            BuildProducer<JsonRPCProvidersBuildItem> rpcProvidersBuildItemBuildProducer) {
+            BuildProducer<MenuPageBuildItem> menuProducer) {
 
         if (!buildTimeConfig.devMode().devUIEnabled() || !buildTimeConfig.devService().enabled()) {
             log.debug(
@@ -61,8 +60,11 @@ public class DevUIZeebeProcessor {
         MenuPageBuildItem menuPageBuildItem = new MenuPageBuildItem();
         menuPageBuildItem.addPage(dashboard);
         menuProducer.produce(menuPageBuildItem);
+    }
 
-        rpcProvidersBuildItemBuildProducer.produce(new JsonRPCProvidersBuildItem(ZeebeJsonRPCService.class));
+    @BuildStep
+    JsonRPCProvidersBuildItem createJsonRPCService() {
+        return new JsonRPCProvidersBuildItem(ZeebeJsonRPCService.class);
     }
 
 }


### PR DESCRIPTION
This is due to an upcoming change in Execution Model Validation [1] where we need the `JsonRPCProvidersBuildItem` produced always, not only in dev mode. JSON RPC providers can use execution model affecting annotations, so we need to know about them, otherwise a non-dev build would fail with an incorrect validation error.

[1] https://github.com/quarkusio/quarkus/pull/46965