### PR TITLE
fix: deprecated system properties variable in pom

### DIFF
--- a/examples/base/pom.xml
+++ b/examples/base/pom.xml
@@ -53,9 +53,9 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${surefire-plugin.version}</version>
                 <configuration>
-                    <systemProperties>
+                    <systemPropertyVariables>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-                    </systemProperties>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
         </plugins>

--- a/examples/opentelemetry/pom.xml
+++ b/examples/opentelemetry/pom.xml
@@ -49,9 +49,9 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${surefire-plugin.version}</version>
                 <configuration>
-                    <systemProperties>
+                    <systemPropertyVariables>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-                    </systemProperties>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
         </plugins>

--- a/examples/reactive/pom.xml
+++ b/examples/reactive/pom.xml
@@ -58,9 +58,9 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${surefire-plugin.version}</version>
                 <configuration>
-                    <systemProperties>
+                    <systemPropertyVariables>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-                    </systemProperties>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
fixes this warning in the logs:

`[WARNING]  Parameter 'systemProperties' is deprecated: Use systemPropertyVariables instead.`