### PR TITLE
fix typo in quarkus.zeebe.client.job.pool-interval

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-zeebe.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-zeebe.adoc
@@ -1134,22 +1134,22 @@ endif::add-copy-button-to-env-var[]
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-zeebe_quarkus-zeebe[icon:question-circle[title=More information about the Duration format]]
 |`PT5M`
 
-a| [[quarkus-zeebe_quarkus-zeebe-client-job-pool-interval]] [.property-path]##link:#quarkus-zeebe_quarkus-zeebe-client-job-pool-interval[`quarkus.zeebe.client.job.pool-interval`]##
+a| [[quarkus-zeebe_quarkus-zeebe-client-job-poll-interval]] [.property-path]##link:#quarkus-zeebe_quarkus-zeebe-client-job-poll-interval[`quarkus.zeebe.client.job.poll-interval`]##
 ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.zeebe.client.job.pool-interval+++[]
+config_property_copy_button:+++quarkus.zeebe.client.job.poll-interval+++[]
 endif::add-copy-button-to-config-props[]
 
 
 [.description]
 --
-Client job pool interval
+Client job poll interval
 
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_ZEEBE_CLIENT_JOB_POOL_INTERVAL+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ZEEBE_CLIENT_JOB_POLL_INTERVAL+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_ZEEBE_CLIENT_JOB_POOL_INTERVAL+++`
+Environment variable: `+++QUARKUS_ZEEBE_CLIENT_JOB_POLL_INTERVAL+++`
 endif::add-copy-button-to-env-var[]
 --
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-zeebe_quarkus-zeebe[icon:question-circle[title=More information about the Duration format]]

--- a/docs/modules/ROOT/pages/includes/quarkus-zeebe_quarkus.zeebe.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-zeebe_quarkus.zeebe.adoc
@@ -1134,22 +1134,22 @@ endif::add-copy-button-to-env-var[]
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-zeebe_quarkus-zeebe[icon:question-circle[title=More information about the Duration format]]
 |`PT5M`
 
-a| [[quarkus-zeebe_quarkus-zeebe-client-job-pool-interval]] [.property-path]##link:#quarkus-zeebe_quarkus-zeebe-client-job-pool-interval[`quarkus.zeebe.client.job.pool-interval`]##
+a| [[quarkus-zeebe_quarkus-zeebe-client-job-poll-interval]] [.property-path]##link:#quarkus-zeebe_quarkus-zeebe-client-job-poll-interval[`quarkus.zeebe.client.job.poll-interval`]##
 ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.zeebe.client.job.pool-interval+++[]
+config_property_copy_button:+++quarkus.zeebe.client.job.poll-interval+++[]
 endif::add-copy-button-to-config-props[]
 
 
 [.description]
 --
-Client job pool interval
+Client job poll interval
 
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_ZEEBE_CLIENT_JOB_POOL_INTERVAL+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ZEEBE_CLIENT_JOB_POLL_INTERVAL+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_ZEEBE_CLIENT_JOB_POOL_INTERVAL+++`
+Environment variable: `+++QUARKUS_ZEEBE_CLIENT_JOB_POLL_INTERVAL+++`
 endif::add-copy-button-to-env-var[]
 --
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-zeebe_quarkus-zeebe[icon:question-circle[title=More information about the Duration format]]

--- a/runtime/src/main/java/io/quarkiverse/zeebe/runtime/ZeebeClientRuntimeConfig.java
+++ b/runtime/src/main/java/io/quarkiverse/zeebe/runtime/ZeebeClientRuntimeConfig.java
@@ -275,9 +275,9 @@ public interface ZeebeClientRuntimeConfig {
         Duration timeout();
 
         /**
-         * Client job pool interval
+         * Client job poll interval
          */
-        @WithName("pool-interval")
+        @WithName("poll-interval")
         @WithDefault("PT0.100S")
         Duration pollInterval();
 


### PR DESCRIPTION
Currently in the `ZeebeClientRuntimeConfig interface` there is the property `quarkus.zeebe.client.job.pool-interval` defined which has the method `pollInterval`. This is then used in the `ZeebeClientBuilderFactory` in `.defaultJobPollInterval(config.job().pollInterval())`. This strongly suggests that `poll-interval` should have been the name for this property since this is the only usage for this property.

**_Note:_** This is just a renaming but could be considered a major change since existing projects which define this variable differently have to migrate to the new spelling.
