### PR TITLE
fix deprecated quarkus property

### DIFF
--- a/integration-tests/panache/pom.xml
+++ b/integration-tests/panache/pom.xml
@@ -11,9 +11,6 @@
     <name>Quarkus - Zeebe - Integration Tests - Panache</name>
     <description>Quarkus Zeebe integration tests Panache</description>
 
-    <properties>
-        <quarkus.package.type>fast-jar</quarkus.package.type>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>io.quarkiverse.zeebe</groupId>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -83,7 +83,8 @@
                 </property>
             </activation>
             <properties>
-                <quarkus.package.type>native</quarkus.package.type>
+                <skipITs>false</skipITs>
+                <quarkus.native.enabled>true</quarkus.native.enabled>
             </properties>
         </profile>
     </profiles>


### PR DESCRIPTION
fixes this warning in the log:
`Configuration property 'quarkus.package.type' has been deprecated and replaced by: [quarkus.package.jar.enabled, quarkus.package.jar.type, quarkus.native.enabled, quarkus.native.sources-only]`

_**Note:**_ `<quarkus.package.type>fast-jar</quarkus.package.type>` is not needed since it is already the default. See here: https://quarkus.io/guides/maven-tooling#fast-jar