### PR TITLE
upgrade maven compiler plugin

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,5 +9,3 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    ignore:
-      - dependency-name: "org.apache.maven.plugins:maven-compiler-plugin"

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <maven.compiler.release>17</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <compiler-plugin.version>3.8.1</compiler-plugin.version>
+    <compiler-plugin.version>3.14.1</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>
     <surefire-plugin.version>3.5.4</surefire-plugin.version>
     <quarkus-mockserver.version>1.13.0</quarkus-mockserver.version>


### PR DESCRIPTION
I am not sure, why the `maven-compiler-plugin` version has been fixed and is not updated by dependabot. IMO dependabot should be able to update this plugin