### PR TITLE
ci: release version 1.7.0

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 name: Camunda Zeebe Quarkus extension
 release:
-  current-version: 1.6.0
+  current-version: 1.7.0
   next-version: 999-SNAPSHOT


### PR DESCRIPTION
I am not sure if version 1.7.0 would be correct.

You could argue that this [PR](https://github.com/quarkiverse/quarkus-zeebe/pull/373) would justify a 2.0.0 version.

I am not sure if this project does semantic versioning so I am fine with whatever you decide @andrejpetras