### PR TITLE
chore: update zeebe client to 8.5.15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
   </scm>
   <properties>
     <quarkus.version>3.20.3</quarkus.version>
-    <zeebe.version>8.5.10</zeebe.version>
+    <zeebe.version>8.5.15</zeebe.version>
     <zeebe.testcontainers.version>3.6.5</zeebe.testcontainers.version>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>


### PR DESCRIPTION
This updates the zeebe client to version 8.5.15 which is the highest version which can be used without something breaking and adjustments needed currently.