### PR TITLE
Use quarkiverse default settings in pom

### DIFF
--- a/examples/base/pom.xml
+++ b/examples/base/pom.xml
@@ -51,7 +51,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>${surefire-plugin.version}</version>
+                <version>${version.surefire.plugin}</version>
                 <configuration>
                     <systemPropertyVariables>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>

--- a/examples/opentelemetry/pom.xml
+++ b/examples/opentelemetry/pom.xml
@@ -47,7 +47,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>${surefire-plugin.version}</version>
+                <version>${version.surefire.plugin}</version>
                 <configuration>
                     <systemPropertyVariables>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>

--- a/examples/reactive/pom.xml
+++ b/examples/reactive/pom.xml
@@ -56,7 +56,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>${surefire-plugin.version}</version>
+                <version>${version.surefire.plugin}</version>
                 <configuration>
                     <systemPropertyVariables>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>

--- a/pom.xml
+++ b/pom.xml
@@ -26,14 +26,6 @@
     <quarkus.version>3.20.3</quarkus.version>
     <zeebe.version>8.5.15</zeebe.version>
     <zeebe.testcontainers.version>3.6.5</zeebe.testcontainers.version>
-    <maven.compiler.source>17</maven.compiler.source>
-    <maven.compiler.target>17</maven.compiler.target>
-    <maven.compiler.release>17</maven.compiler.release>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <compiler-plugin.version>3.14.1</compiler-plugin.version>
-    <maven.compiler.parameters>true</maven.compiler.parameters>
-    <surefire-plugin.version>3.5.4</surefire-plugin.version>
     <quarkus-mockserver.version>1.14.0</quarkus-mockserver.version>
   </properties>
   <dependencyManagement>
@@ -102,7 +94,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>${compiler-plugin.version}</version>
+          <version>${version.compiler.plugin}</version>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
We are defining values like source encoding, java version and compiler plugin version explicitly in our pom. Even though there is no need for that since we have no special needs for that versions. We can simply use the quarkivierse pom defaults for that. They're currently the same values that were set by our pom. So we can simplify these properties and actually define properties we really need